### PR TITLE
Feat: 재사용 가능한 Kotlin Check 및 Mortar deploy workflow(check-kotlin, deploy-mortar)

### DIFF
--- a/.github/actions/cancel-previous-workflows/action.yml
+++ b/.github/actions/cancel-previous-workflows/action.yml
@@ -1,0 +1,29 @@
+name: "Cancel Previous Workflows"
+description: "cancel previous workflows with same id"
+inputs:
+  run-id:
+    description: "run id of current workflows"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup gh CLI
+      uses: ksivamuthu/gh-cli-action@v1
+    - name: Get current workflow run information
+      id: current-run
+      run: |
+        DATA=$(gh run view ${{ github.run_id }} --json workflowDatabaseId,createdAt)
+        WORKFLOW_ID=$(jq .workflowDatabaseId "${DATA}")
+        CREATED_AT=$(jq '.createdAt|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime' "${DATA}")
+        CANDIDATES=$(gh run list --json status,createdAt,databaseId,workflowDatabaseId -L 100 --jq ".[] | \
+          select( \
+            (.status | in(["queued", "in_progress", "waiting"])) and \
+            .databaseId != ${{github.run_id}} and \
+            .workflowDatabaseId == ${WORKFLOW_ID} and \
+            (.createdAt | strptime(\"%Y-%m-%dT%H:%M:%SZ\")|mktime) > ${CREATED_AT} \
+          ) | .databaseId ')
+        echo $CANDIDATES | while read cand; do
+          gh run cancel $cand
+        done
+      shell: bash

--- a/.github/actions/cancel-previous-workflows/action.yml
+++ b/.github/actions/cancel-previous-workflows/action.yml
@@ -8,8 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup gh CLI
-      uses: ksivamuthu/gh-cli-action@v1
+    - name: Install GH CLI
+      uses: dev-hanz-ops/install-gh-cli-action
     - name: Get current workflow run information
       id: current-run
       run: |

--- a/.github/actions/cancel-previous-workflows/action.yml
+++ b/.github/actions/cancel-previous-workflows/action.yml
@@ -8,11 +8,29 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install GH CLI
-      uses: dev-hanz-ops/install-gh-cli-action
     - name: Get current workflow run information
       id: current-run
+      env:
+        GH_VERSION: "2.15.0"
       run: |
+        gh --help 2&>1 >> /dev/null
+        if [[ $? -ne 0 ]]; then
+          mkdir _temp-gh
+          OA="${{ runner.arch }}"
+          if [[ $OA == "X64" ]]; then 
+            GH_ARCH=amd64
+          elif [[ $OA == "ARM64" ]]; then
+            GH_ARCH=arm64
+          elif [[ $OA == "X86" ]]; then
+            GH_ARCH=386
+          elif [[ $OA == "ARM" ]]; then
+            GH_ARCH=armv6
+          fi
+          curl -Lsf https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${{ runner.os }}_${GH_ARCH}.tar.gz | tar -xz --strip-components 1 -C temp
+          chmod u+x _temp-gh/bin/gh
+          alias gh=_temp-gh/bin/gh
+        fi
+
         DATA=$(gh run view ${{ github.run_id }} --json workflowDatabaseId,createdAt)
         WORKFLOW_ID=$(jq .workflowDatabaseId "${DATA}")
         CREATED_AT=$(jq '.createdAt|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime' "${DATA}")
@@ -26,4 +44,5 @@ runs:
         echo $CANDIDATES | while read cand; do
           gh run cancel $cand
         done
+        rm -rf _temp-gh
       shell: bash

--- a/.github/actions/release-tag-finder/action.yml
+++ b/.github/actions/release-tag-finder/action.yml
@@ -1,0 +1,64 @@
+name: "Release Tag Finder"
+description: "finds release tags and generate next tag with app name"
+inputs:
+  app-name:
+    description: "앱 기준 디렉토리"
+    required: true
+  bump:
+    description: "next tag에서 SemVer 어떤 부분(major, minor, patch)를 올릴지 결정"
+    default: "patch"
+    required: false
+  github-token:
+    description: "github token"
+    required: true
+outputs:
+  next-tag:
+    description: "다음 Tag 명 (eg. sample-service-v1.0.1)"
+    value: ${{ steps.generate-next-tag.outputs.tag }}
+  current-tag:
+    description: "현재 Tag 명 (eg. sample-service-v1.0.0)"
+    value: ${{ steps.current-tag.outputs.tag }}
+  next-version:
+    description: "다음 Version (eg. 1.0.1)"
+    value: ${{ steps.generate-next-tag.outputs.version }}
+  current-version:
+    description: "현재 Version (eg. 1.0.0)"
+    value: ${{ steps.current-tag.outputs.version }}
+  
+runs:
+  using: composite
+  steps:
+    - name: "Find Latest Tags for new Version"
+      id: find-latest-tag  # The step ID to refer to later.
+      uses: oprypin/find-latest-tag@v1
+      with:
+        repository: ${{ github.repository }}
+        releases-only: true
+        prefix: "${{ inputs.app-name }}-v"
+    - name: Get Current Tag and Version
+      id: current-tag
+      run: |
+        LATEST_TAG="${{ steps.find-latest-tag.outputs.tag }}"
+        LATEST_VERSION="${LATEST_TAG#${{ inputs.app-name }}-v}"
+        echo "::set-output name=tag::${LATEST_TAG}"
+        echo "::set-output name=version::${LATEST_VERSION}"
+      shell: bash
+    - name: Get Next SemVer
+      id: next-semver
+      uses: "WyriHaximus/github-action-next-semvers@v1"
+      with:
+        version: ${{ steps.current-tag.outputs.version }}
+    - name: Generate Next Tag and Version
+      id: generate-next-tag
+      run: |
+        GEN_VERSION="${{ steps.next-semver.outputs.patch }}"
+        if [[ "${{ inputs.bump }}" == "minor" ]]; then
+          GEN_VERSION="${{ steps.next-semver.outputs.minor }}"
+        fi
+        if [[ "${{ inputs.bump }}" == "major" ]]; then
+          GEN_VERSION="${{ steps.next-semver.outputs.major }}"
+        fi
+        GEN_TAG="${{ inputs.app-name }}-v${GEN_VERSION}"
+        echo "::set-output name=tag::${GEN_TAG}"
+        echo "::set-output name=version::${GEN_VERSION}"
+      shell: bash

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -50,19 +50,24 @@ jobs:
             exit 100
           fi
         shell: bash
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Checkout Code for Get Main SHA
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          path: ${{ github.workspace }}/get-sha-temp
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Get Main SHA
+        id: get-sha
+        run: |
+          cd ${{ github.workspace }}/get-sha-temp
+          echo "::set-output name=sha::$(git rev-parse --short=10 HEAD)"
+          rm -rf ${{ github.workspace }}/get-sha-temp
+      - name: Checkout code
+        uses: actions/checkout@v3
       - if: ${{ !inputs.prod }}
         name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
-      - name: Get Main SHA
-        id: get-sha
-        run: |
-          echo "::set-output name=sha::$(git rev-parse --short=10 refs/remotes/origin/${{ github.event.repository.default_branch }})"
       - name: Check Conditions
         id: check-conditions
         run: |

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -52,6 +52,8 @@ jobs:
         shell: bash
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - if: ${{ !inputs.prod }}
         name: Setup Reviewdog
         uses: reviewdog/action-setup@v1

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -52,6 +52,8 @@ jobs:
         shell: bash
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - if: ${{ !inputs.prod }}
         name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
@@ -60,7 +62,7 @@ jobs:
       - name: Get Main SHA
         id: get-sha
         run: |
-          echo "::set-output name=sha::$(git rev-parse refs/remotes/origin/HEAD)"
+          echo "::set-output name=sha::$(git rev-parse refs/heads/${{ github.event.repository.default_branch }} --short=7)"
       - name: Check Conditions
         id: check-conditions
         run: |
@@ -74,7 +76,7 @@ jobs:
           fi
           SONAR_VERSION="${{ steps.get-sha.outputs.sha }}"
           if [[ "${{ inputs.prod }}" != "true" ]]; then
-            SONAR_VERSION="${SONAR_VERSION}-candidate"
+            SONAR_VERSION="${SONAR_VERSION}-pr"
           fi
 
           echo "::set-output name=reviewdog-reporter::${RD_REPORT}"

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -72,7 +72,7 @@ jobs:
             RD_REPORT="local"
             RD_DIFF="-diff=\"git diff ${{ steps.get-sha.outputs.sha }} ${{ inputs.app-path }}"
           fi
-          SONAR_VERSION="${{ teps.get-sha.outputs.sha }}"
+          SONAR_VERSION="${{ steps.get-sha.outputs.sha }}"
           if [[ "${{ inputs.prod }}" != "true" ]]; then
             SONAR_VERSION="${SONAR_VERSION}-candidate"
           fi

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -27,19 +27,11 @@ on:
         description: "host url of sonarqube"
         required: false
         default: "https://sonarqube.co-workerhou.se"
-    outputs:
-      next-tag:
-        description: "다음 Tag 명 (eg. sample-service-v1.0.1)"
-        value: ${{ jobs.check-and-report.outputs.next-tag }}
-      current-tag:
-        description: "현재 Tag 명 (eg. sample-service-v1.0.0)"
-        value: ${{ jobs.check-and-report.outputs.current-tag }}
-      next-version:
-        description: "다음 Version (eg. 1.0.1)"
-        value: ${{ jobs.check-and-report.outputs.next-version }}
-      current-version:
-        description: "현재 Version (eg. 1.0.0)"
-        value: ${{ jobs.check-and-report.outputs.current-version }}
+      prod:
+        type: boolean
+        description: "true if prod"
+        default: false
+        required: false
     secrets:
       SONAR_TOKEN:
         required: true
@@ -47,11 +39,6 @@ jobs:
   check-and-report:
     name: Lint, Test And Reports
     runs-on: [self-hosted, Linux, X64, mortar-runner]
-    outputs:
-      next-tag: ${{ steps.get-tag.outputs.next-tag }}
-      current-tag: ${{ steps.get-tag.outputs.current-tag }}
-      next-version: ${{ steps.get-tag.outputs.next-version }}
-      current-version: ${{ steps.get-tag.outputs.current-version }}
     steps:
       - if: ${{ inputs.version != ''}}
         name: Check Version
@@ -65,16 +52,15 @@ jobs:
         shell: bash
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Setup Reviewdog
+      - if: ${{ !inputs.prod }}
+        name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
-      - name: Get Current Tag
-        id: get-tag
-        uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@main
-        with:
-          app-name: ${{ inputs.app-name }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Main SHA
+        id: get-sha
+        run: |
+          echo "::set-output name=sha::$(git rev-parse refs/remotes/origin/HEAD)"
       - name: Check Conditions
         id: check-conditions
         run: |
@@ -84,16 +70,17 @@ jobs:
             RD_REPORT="github-check"
           else
             RD_REPORT="local"
-            RD_DIFF="-diff=\"git diff ${{ steps.get-tag.outputs.current-tag }} ${{ inputs.app-path }}"
+            RD_DIFF="-diff=\"git diff ${{ steps.get-sha.outputs.sha }} ${{ inputs.app-path }}"
           fi
-          VERSION="${{ inputs.version }}"
-          if [[ -z "${{ inputs.version }}" ]]; then
-            VERSION="${{ steps.get-tag.outputs.next-version }}"
+          SONAR_VERSION="${{ teps.get-sha.outputs.sha }}"
+          if [[ "${{ inputs.prod }}" != "true" ]]; then
+            SONAR_VERSION="${SONAR_VERSION}-candidate"
           fi
-          
+
           echo "::set-output name=reviewdog-reporter::${RD_REPORT}"
           echo "::set-output name=reviewdog-diff::${RD_DIFF}"
-          echo "::set-output name=version::${VERSION}"
+          echo "::set-output name=sonar_version::${SONAR_VERSION}"
+          echo "::set-output name=quality-gate::${{!inputs.prod}}"
         shell: bash
       - name: Report Summary
         run: |
@@ -104,7 +91,7 @@ jobs:
           | App Name | ${{ inputs.app-name }} |
           | App Path | ${{ inputs.app-path }} |
           | Gradle Path | ${{ inputs.gradlew-path}}/gradlew |
-          | Version | ${{ steps.check-conditions.outputs.version }} |
+          | Sonar Version | ${{ steps.check-conditions.outputs.sonar_version }} |
           | Deployed By | @${{ github.actor }} |
 
           EOF
@@ -130,8 +117,8 @@ jobs:
           --project-dir=${{ inputs.app-path }} \
           --info \
           --continue \
-          -Dsonar.qualitygate.wait=true \
-          -Dsonar.projectVersion='${{ steps.check-conditions.outputs.version }}' \
+          -Dsonar.qualitygate.wait=${{ steps.check-conditions.outputs.quality-gate }} \
+          -Dsonar.projectVersion='${{ steps.check-conditions.outputs.sonar_version }}' \
           -Dsonar.projectName="${{ inputs.app-name }}"
         shell: bash
       - if: failure()
@@ -140,7 +127,7 @@ jobs:
         with:
           name: Failure Reports
           path: ${{ inputs.app-path }}/build/reports/
-      - if: always() && github.event_name != 'workflow_dispatch'
+      - if: always() && github.event_name != 'workflow_dispatch' && !inputs.prod
         name: Add coverage to PR
         uses: madrapps/jacoco-report@v1.3
         with:
@@ -148,7 +135,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 70
           min-coverage-changed-files: 70
-      - if: always() 
+      - if: always() && !inputs.prod
         name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -52,8 +52,6 @@ jobs:
         shell: bash
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - if: ${{ !inputs.prod }}
         name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
@@ -62,7 +60,7 @@ jobs:
       - name: Get Main SHA
         id: get-sha
         run: |
-          echo "::set-output name=sha::$(git rev-parse refs/heads/${{ github.event.repository.default_branch }} --short=7)"
+          echo "::set-output name=sha::$(git rev-parse --short=10 refs/remotes/origin/${{ github.event.repository.default_branch }})"
       - name: Check Conditions
         id: check-conditions
         run: |
@@ -113,7 +111,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
-          GRADLE_HOME: /runner/.gradle
+          GRADLE_USER_HOME: /runner/.gradle
         run: |
           ${{ inputs.gradlew-path }}/gradlew check jacocoTestReport sonarqube \
           --project-dir=${{ inputs.app-path }} \

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -1,0 +1,174 @@
+name: "Check Kotlin"
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: "앱 이름"
+        required: true
+        type: string
+      app-path:
+        type: string
+        description: "앱 기준 디렉토리"
+        required: false
+        default: "."
+      version:
+        description: "릴리즈 Tag (semver, eg. X.X.X)"
+        required: false
+        type: string
+        default: ""
+      gradlew-path:
+        type: string
+        description: "gradlew가 있는 path"
+        required: false
+        default: "."
+      sonar-host-url:
+        type: string
+        description: "host url of sonarqube"
+        required: false
+        default: "https://sonarqube.co-workerhou.se"
+    outputs:
+      next-tag:
+        description: "다음 Tag 명 (eg. sample-service-v1.0.1)"
+        value: ${{ jobs.check-and-report.outputs.next-tag }}
+      current-tag:
+        description: "현재 Tag 명 (eg. sample-service-v1.0.0)"
+        value: ${{ jobs.check-and-report.outputs.current-tag }}
+      next-version:
+        description: "다음 Version (eg. 1.0.1)"
+        value: ${{ jobs.check-and-report.outputs.next-version }}
+      current-version:
+        description: "현재 Version (eg. 1.0.0)"
+        value: ${{ jobs.check-and-report.outputs.current-version }}
+    secrets:
+      SONAR_TOKEN:
+        required: true
+jobs:   
+  check-and-report:
+    name: Lint, Test And Reports
+    runs-on: [self-hosted, Linux, X64, mortar-runner]
+    outputs:
+      next-tag: ${{ steps.get-tag.outputs.next-tag }}
+      current-tag: ${{ steps.get-tag.outputs.current-tag }}
+      next-version: ${{ steps.get-tag.outputs.next-version }}
+      current-version: ${{ steps.get-tag.outputs.current-version }}
+    steps:
+      - if: ${{ inputs.version != ''}}
+        name: Check Version
+        id: check-version
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+[\.][0-9]+[\.][0-9]+$ ]];then
+            echo "invalid version: ${{ inputs.version }}" 1>&2
+            echo "버전 포멧이 맞지 않습니다. 버전은 반드시 x.x.x 이어야 합니다 (v 제외): ${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+            exit 100
+          fi
+        shell: bash
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Setup Reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
+      - name: Get Current Tag
+        id: get-tag
+        uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@main
+        with:
+          app-name: ${{ inputs.app-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Conditions
+        id: check-conditions
+        run: |
+          if [[ "${{ startsWith(github.event_name, 'pull_request') }}" == "true" ]]; then
+            RD_REPORT="github-pr-review"
+          elif [[ "${{ github.event.head_commit != null }}" == "true" ]]; then
+            RD_REPORT="github-check"
+          else
+            RD_REPORT="local"
+            RD_DIFF="-diff=\"git diff ${{ steps.get-tag.outputs.current-tag }} ${{ inputs.app-path }}"
+          fi
+          VERSION="${{ inputs.version }}"
+          if [[ -z "${{ inputs.version }}" ]]; then
+            VERSION="${{ steps.get-tag.outputs.next-version }}"
+          fi
+          
+          echo "::set-output name=reviewdog-reporter::${RD_REPORT}"
+          echo "::set-output name=reviewdog-diff::${RD_DIFF}"
+          echo "::set-output name=version::${VERSION}"
+        shell: bash
+      - name: Report Summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Request Information
+          | Name | Details |
+          | --- | --- |
+          | App Name | ${{ inputs.app-name }} |
+          | App Path | ${{ inputs.app-path }} |
+          | Gradle Path | ${{ inputs.gradlew-path}}/gradlew |
+          | Version | ${{ steps.check-conditions.outputs.version }} |
+          | Deployed By | @${{ github.actor }} |
+
+          EOF
+
+          if [[ -f "${{ inputs.app-path }}"/mortar.yaml ]]; then
+              echo "<details><summary><b>mortar.yaml</b></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '``` yaml' >> "$GITHUB_STEP_SUMMARY"
+              cat "${{ inputs.app-path }}"/mortar.yaml >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi 
+        shell: bash
+      - name: Run gradle for lint, test and sonarqube
+        id: gradle-run
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
+          GRADLE_HOME: /runner/.gradle
+        run: |
+          ${{ inputs.gradlew-path }}/gradlew check jacocoTestReport sonarqube \
+          --project-dir=${{ inputs.app-path }} \
+          --info \
+          --continue \
+          -Dsonar.qualitygate.wait=true \
+          -Dsonar.projectVersion='${{ steps.check-conditions.outputs.version }}' \
+          -Dsonar.projectName="${{ inputs.app-name }}"
+        shell: bash
+      - if: failure()
+        name: Upload Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: Failure Reports
+          path: ${{ inputs.app-path }}/build/reports/
+      - if: always() && github.event_name != 'workflow_dispatch'
+        name: Add coverage to PR
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: ${{ inputs.app-path }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+      - if: always() 
+        name: Run reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORTS_DIR: ${{ inputs.app-path }}/build/reports
+        continue-on-error: true
+        run: |
+          function review {
+            file=$1
+            review_name=$2
+            if [[ -f "$file" ]]; then
+              cat "$file" | reviewdog \
+              -reporter="${{ steps.check-conditions.outputs.reviewdog-reporter }}" \
+              -f=checkstyle \
+              --name="${review_name}" \
+               ${{steps.check-conditions.outputs.reviewdog-diff}}
+            fi
+          }
+          review "$REPORTS_DIR"/ktlint/ktlintKotlinScriptCheck/ktlintKotlinScriptCheck.xml "Report / ktlint-script"
+          review "$REPORTS_DIR"/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.xml "Report / ktlint-source"
+          review "$REPORTS_DIR"/ktlint/ktlintTestSourceSetCheck/ktlintTestSourceSetCheck.xml "Report / ktlint-test"
+          review "$REPORTS_DIR"/detekt/detekt.xml "Report / detekt"
+        shell: bash
+  

--- a/.github/workflows/reusable-check-kotlin.yml
+++ b/.github/workflows/reusable-check-kotlin.yml
@@ -12,11 +12,6 @@ on:
         description: "앱 기준 디렉토리"
         required: false
         default: "."
-      version:
-        description: "릴리즈 Tag (semver, eg. X.X.X)"
-        required: false
-        type: string
-        default: ""
       gradlew-path:
         type: string
         description: "gradlew가 있는 path"
@@ -27,11 +22,6 @@ on:
         description: "host url of sonarqube"
         required: false
         default: "https://sonarqube.co-workerhou.se"
-      prod:
-        type: boolean
-        description: "true if prod"
-        default: false
-        required: false
     secrets:
       SONAR_TOKEN:
         required: true
@@ -40,16 +30,6 @@ jobs:
     name: Lint, Test And Reports
     runs-on: [self-hosted, Linux, X64, mortar-runner]
     steps:
-      - if: ${{ inputs.version != ''}}
-        name: Check Version
-        id: check-version
-        run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+[\.][0-9]+[\.][0-9]+$ ]];then
-            echo "invalid version: ${{ inputs.version }}" 1>&2
-            echo "버전 포멧이 맞지 않습니다. 버전은 반드시 x.x.x 이어야 합니다 (v 제외): ${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-            exit 100
-          fi
-        shell: bash
       - name: Checkout Code for Get Main SHA
         uses: actions/checkout@v3
         with:
@@ -59,12 +39,11 @@ jobs:
         id: get-sha
         run: |
           cd ${{ github.workspace }}/get-sha-temp
-          echo "::set-output name=sha::$(git rev-parse --short=10 HEAD)"
+          echo "::set-output name=short-sha::$(git rev-parse --short=10 HEAD)"
           rm -rf ${{ github.workspace }}/get-sha-temp
       - name: Checkout code
         uses: actions/checkout@v3
-      - if: ${{ !inputs.prod }}
-        name: Setup Reviewdog
+      - name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
@@ -79,15 +58,9 @@ jobs:
             RD_REPORT="local"
             RD_DIFF="-diff=\"git diff ${{ steps.get-sha.outputs.sha }} ${{ inputs.app-path }}"
           fi
-          SONAR_VERSION="${{ steps.get-sha.outputs.sha }}"
-          if [[ "${{ inputs.prod }}" != "true" ]]; then
-            SONAR_VERSION="${SONAR_VERSION}-pr"
-          fi
 
           echo "::set-output name=reviewdog-reporter::${RD_REPORT}"
           echo "::set-output name=reviewdog-diff::${RD_DIFF}"
-          echo "::set-output name=sonar_version::${SONAR_VERSION}"
-          echo "::set-output name=quality-gate::${{!inputs.prod}}"
         shell: bash
       - name: Report Summary
         run: |
@@ -102,7 +75,6 @@ jobs:
           | Deployed By | @${{ github.actor }} |
 
           EOF
-
           if [[ -f "${{ inputs.app-path }}"/mortar.yaml ]]; then
               echo "<details><summary><b>mortar.yaml</b></summary>" >> "$GITHUB_STEP_SUMMARY"
               echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -124,8 +96,8 @@ jobs:
           --project-dir=${{ inputs.app-path }} \
           --info \
           --continue \
-          -Dsonar.qualitygate.wait=${{ steps.check-conditions.outputs.quality-gate }} \
-          -Dsonar.projectVersion='${{ steps.check-conditions.outputs.sonar_version }}' \
+          -Dsonar.qualitygate.wait=true \
+          -Dsonar.projectVersion='${{ steps.get-sha.outputs.short-sha }}-pr' \
           -Dsonar.projectName="${{ inputs.app-name }}"
         shell: bash
       - if: failure()
@@ -134,7 +106,7 @@ jobs:
         with:
           name: Failure Reports
           path: ${{ inputs.app-path }}/build/reports/
-      - if: always() && github.event_name != 'workflow_dispatch' && !inputs.prod
+      - if: always() && github.event_name != 'workflow_dispatch'
         name: Add coverage to PR
         uses: madrapps/jacoco-report@v1.3
         with:
@@ -142,7 +114,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 70
           min-coverage-changed-files: 70
-      - if: always() && !inputs.prod
+      - if: always()
         name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -88,7 +88,7 @@ jobs:
     needs: [validate-and-check]
     runs-on: [self-hosted, Linux, X64, mortar-runner]
     outputs:
-      image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
+      image-tag: ${{ steps.mortar-deploy.outputs.app-version }}
     env:
       GRADLE_USER_HOME: /runner/.gradle
     steps:
@@ -184,7 +184,7 @@ jobs:
     needs: [deploy-testing]
     runs-on: [self-hosted, Linux, X64, mortar-runner]
     outputs:
-      image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
+      image-tag: ${{ steps.mortar-deploy.outputs.app-version }}
     env:
       GRADLE_USER_HOME: /runner/.gradle
     steps:

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -71,7 +71,7 @@ on:
 
 jobs:
   submit-sonarqube:
-    name: Validate
+    name: ""
     uses: './.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml'
     with:
       app-name: ${{ inputs.app-name }}

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -1,0 +1,228 @@
+name: "Deploy Mortar Application"
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        type: string
+        description: "앱 이름"
+        required: true
+      app-path:
+        type: string
+        description: "앱 기준 디렉토리"
+        required: false
+        default: "."
+      version:
+        description: "릴리즈 Tag (semver, eg. X.X.X)"
+        required: false
+        type: string
+      release-note:
+        description: "릴리즈 기록"
+        default: "특이사항 없음"
+        required: false
+        type: string
+      auto-release:
+        type: boolean
+        description: "Release 생성 여부"
+        default: true
+        required: false
+      nexus-url:
+        type: string
+        description: "Nexus URL where all the packages are published"
+        required: false
+        default: "http://nexus.dailyhou.se"
+      create-ecr-repo:
+        type: boolean
+        description: "creates ECR repository if it is not existed"
+        required: false
+        default: false
+      gradlew-path:
+        type: string
+        description: "gradlew가 있는 path"
+        required: false
+        default: "."
+      sonar-host-url:
+        type: string
+        description: "host url of sonarqube"
+        required: false
+        default: "https://sonarqube.co-workerhou.se"
+
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: "An AWS access key ID for deploying image into ECR"
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: "An AWS secret access key for deploying image into ECR"
+        required: true
+      GO_REPO_S3_AWS_ACCESS_KEY_ID:
+        description: "An AWS secret access key ID for deploying go package into S3"
+        required: false
+      GO_REPO_S3_AWS_SECRET_ACCESS_KEY:
+        description: "An AWS secret secret access key for deploying go package into S3"
+        required: false
+      NEXUS_DEPLOY_USERPASS:
+        description: "Pair of Username and Password for accessing nexus"
+        required: true
+      OPSMONSTER_AUTH_TOKEN_V2:
+        required: true
+      OPSMONSTER_BASE_URL_V2:
+        required: true
+      SONAR_TOKEN:
+        required: true
+
+jobs:
+  validate-and-check:
+    name: Validate
+    uses: './.github/workflows/reusable-check-kotlin.yml'
+    with:
+      app-name: ${{ inputs.app-name }}
+      app-path: ${{ inputs.app-path }}
+      version: ${{ inputs.version }}
+      gradlew-path: ${{ inputs.gradlew-path }}
+      sonar-host-url: ${{ inputs.sonar-host-url }}
+    secrets: inherit
+
+  build-and-push-nonprod:
+    environment: dev
+    name: Build - NonProd
+    needs: [validate-and-check]
+    runs-on: [self-hosted, Linux, X64, mortar-runner]
+    outputs:
+      image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
+    env:
+      GRADLE_HOME: /runner/.gradle
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Mortar Deploy
+        id: mortar-deploy
+        uses: bucketplace/mortar-deploy-action@v1
+        with:
+          prod: false
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          go-repo-s3-aws-access-id: ${{ secrets.GO_REPO_S3_AWS_ACCESS_KEY_ID }}
+          go-repo-s3-aws-secret-key: ${{ secrets.GO_REPO_S3_AWS_SECRET_ACCESS_KEY }}
+          nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
+          nexus-url: ${{ inputs.nexus-url }}
+          override-version: ${{ needs.validate-and-check.outputs.next-version }}
+          config: ${{ inputs.app-path }}
+          create-ecr-repo: ${{ inputs.create-ecr-repo }}
+      - if: failure()
+        name: Report failure
+        run: |
+          echo "Mortar 실행이 실패하였습니다." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+  
+  cd-trigger-dev:
+    environment: dev
+    name: Deploy - Dev
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: [build-and-push-nonprod]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.app-name }}
+          profile: dev
+          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+
+  cd-trigger-testing:
+    environment: testing
+    name: Deploy - Testing
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: [build-and-push-nonprod]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.app-name }}
+          profile: testing
+          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+  
+  cd-trigger-staging:
+    environment: staging
+    name: Deploy - Staging
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: [build-and-push-nonprod]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.app-name }}
+          profile: staging
+          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+
+  build-and-push-prod:
+    environment: prod
+    name: Build - Prod
+    needs: [validate-and-check, cd-trigger-testing]
+    runs-on: [self-hosted, Linux, X64, mortar-runner]
+    outputs:
+      image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
+    env:
+      GRADLE_HOME: /runner/.gradle
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Mortar Deploy
+        id: mortar-deploy
+        uses: bucketplace/mortar-deploy-action@v1
+        with:
+          prod: true
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          go-repo-s3-aws-access-id: ${{ secrets.GO_REPO_S3_AWS_ACCESS_KEY_ID }}
+          go-repo-s3-aws-secret-key: ${{ secrets.GO_REPO_S3_AWS_SECRET_ACCESS_KEY }}
+          nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
+          nexus-url: ${{ inputs.nexus-url }}
+          override-version: ${{ needs.validate-and-check.outputs.next-version }}
+          config: ${{ inputs.app-path }}
+          create-ecr-repo: ${{ inputs.create-ecr-repo }}
+      - if: failure()
+        name: Report failure
+        run: |
+          echo "Mortar 실행이 실패하였습니다." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+  
+  cd-trigger-prod:
+    environment: prod
+    name: Deploy - Prod
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: [build-and-push-prod]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.app-name }}
+          profile: prod
+          image-tag: ${{  steps.build-and-push-prod.outputs.image-tag  }}
+          version: ${{  steps.build-and-push-prod.outputs.image-tag  }}
+  
+  github-release:
+    if: inputs.auto-release
+    name: Release
+    needs: [validate-and-check, build-and-push-prod]
+    uses: './.github/workflows/reusable-github-release.yml'
+    with:
+      app-name: ${{ inputs.app-name }}
+      version: ${{ needs.validate-and-check.outputs.next-version }}
+      release-note: ${{ inputs.release-note }}
+    secrets: inherit

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -90,7 +90,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
     env:
-      GRADLE_HOME: /runner/.gradle
+      GRADLE_USER_HOME: /runner/.gradle
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
     env:
-      GRADLE_HOME: /runner/.gradle
+      GRADLE_USER_HOME: /runner/.gradle
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -93,7 +93,7 @@ jobs:
       GRADLE_USER_HOME: /runner/.gradle
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Tag
         id: get-tag
         uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@v1
@@ -189,7 +189,7 @@ jobs:
       GRADLE_USER_HOME: /runner/.gradle
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Tag
         id: get-tag
         uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@v1

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -46,7 +46,6 @@ on:
         description: "host url of sonarqube"
         required: false
         default: "https://sonarqube.co-workerhou.se"
-
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "An AWS access key ID for deploying image into ECR"
@@ -71,21 +70,18 @@ on:
         required: true
 
 jobs:
-  validate-and-check:
+  submit-sonarqube:
     name: Validate
-    uses: './.github/workflows/reusable-check-kotlin.yml'
+    uses: './.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml'
     with:
       app-name: ${{ inputs.app-name }}
       app-path: ${{ inputs.app-path }}
-      version: ${{ inputs.version }}
       gradlew-path: ${{ inputs.gradlew-path }}
       sonar-host-url: ${{ inputs.sonar-host-url }}
-      prod: true
     secrets: inherit
 
   build-and-push-nonprod:
     name: Build - NonProd
-    needs: [validate-and-check]
     runs-on: [self-hosted, Linux, X64, mortar-runner]
     outputs:
       image-tag: ${{ steps.mortar-deploy.outputs.app-version }}
@@ -140,7 +136,7 @@ jobs:
   deploy-testing:
     environment: testing
     concurrency: 
-      group: ci-${{ inputs.app-name }}
+      group: ci-testing-${{ inputs.app-name }}
     name: Deploy - Testing
     runs-on: [self-hosted, Linux, X64, no-cache]
     needs: [build-and-push-nonprod]

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -83,7 +83,6 @@ jobs:
     secrets: inherit
 
   build-and-push-nonprod:
-    environment: dev
     name: Build - NonProd
     needs: [validate-and-check]
     runs-on: [self-hosted, Linux, X64, mortar-runner]
@@ -94,11 +93,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Get Tag
+        id: get-tag
+        uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@v1
+        with:
+          app-name: ${{ inputs.app-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Mortar Deploy
         id: mortar-deploy
         uses: bucketplace/mortar-deploy-action@v1
         with:
-          prod: false
           aws-region: ap-northeast-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -106,7 +110,7 @@ jobs:
           go-repo-s3-aws-secret-key: ${{ secrets.GO_REPO_S3_AWS_SECRET_ACCESS_KEY }}
           nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
           nexus-url: ${{ inputs.nexus-url }}
-          override-version: ${{ needs.validate-and-check.outputs.next-version }}
+          override-version: ${{ steps.get-tag.outputs.next-version }}
           config: ${{ inputs.app-path }}
           create-ecr-repo: ${{ inputs.create-ecr-repo }}
       - if: failure()
@@ -115,7 +119,7 @@ jobs:
           echo "Mortar 실행이 실패하였습니다." >> "$GITHUB_STEP_SUMMARY"
           exit 1
   
-  cd-trigger-dev:
+  deploy-dev:
     environment: dev
     name: Deploy - Dev
     runs-on: [self-hosted, Linux, X64, no-cache]
@@ -132,8 +136,10 @@ jobs:
           image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
           version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
 
-  cd-trigger-testing:
+  deploy-testing:
     environment: testing
+    concurrency: 
+      group: ci-${{ inputs.app-name }}
     name: Deploy - Testing
     runs-on: [self-hosted, Linux, X64, no-cache]
     needs: [build-and-push-nonprod]
@@ -148,8 +154,13 @@ jobs:
           profile: testing
           image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
           version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+      - name: Cancel previous workflows run
+        uses: bucketplace/github-action-ci-workflows/.github/actions/cancel-previous-workflows@v1
+        with:
+          app-name: ${{ inputs.app-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   
-  cd-trigger-staging:
+  deploy-staging:
     environment: staging
     name: Deploy - Staging
     runs-on: [self-hosted, Linux, X64, no-cache]
@@ -169,7 +180,7 @@ jobs:
   build-and-push-prod:
     environment: prod
     name: Build - Prod
-    needs: [validate-and-check, cd-trigger-testing]
+    needs: [deploy-testing]
     runs-on: [self-hosted, Linux, X64, mortar-runner]
     outputs:
       image_tag: ${{ steps.mortar-deploy.outputs.app-version }}
@@ -178,6 +189,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Get Tag
+        id: get-tag
+        uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@v1
+        with:
+          app-name: ${{ inputs.app-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Mortar Deploy
         id: mortar-deploy
         uses: bucketplace/mortar-deploy-action@v1
@@ -190,7 +207,7 @@ jobs:
           go-repo-s3-aws-secret-key: ${{ secrets.GO_REPO_S3_AWS_SECRET_ACCESS_KEY }}
           nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
           nexus-url: ${{ inputs.nexus-url }}
-          override-version: ${{ needs.validate-and-check.outputs.next-version }}
+          override-version: ${{ steps.get-tag.outputs.next-version }}
           config: ${{ inputs.app-path }}
           create-ecr-repo: ${{ inputs.create-ecr-repo }}
       - if: failure()
@@ -199,7 +216,7 @@ jobs:
           echo "Mortar 실행이 실패하였습니다." >> "$GITHUB_STEP_SUMMARY"
           exit 1
   
-  cd-trigger-prod:
+  deploy-prod:
     environment: prod
     name: Deploy - Prod
     runs-on: [self-hosted, Linux, X64, no-cache]
@@ -219,10 +236,9 @@ jobs:
   github-release:
     if: inputs.auto-release
     name: Release
-    needs: [validate-and-check, build-and-push-prod]
+    needs: [build-and-push-prod]
     uses: './.github/workflows/reusable-github-release.yml'
     with:
       app-name: ${{ inputs.app-name }}
-      version: ${{ needs.validate-and-check.outputs.next-version }}
       release-note: ${{ inputs.release-note }}
     secrets: inherit

--- a/.github/workflows/reusable-deploy-mortar.yml
+++ b/.github/workflows/reusable-deploy-mortar.yml
@@ -80,6 +80,7 @@ jobs:
       version: ${{ inputs.version }}
       gradlew-path: ${{ inputs.gradlew-path }}
       sonar-host-url: ${{ inputs.sonar-host-url }}
+      prod: true
     secrets: inherit
 
   build-and-push-nonprod:
@@ -133,8 +134,8 @@ jobs:
         with:
           application: ${{ inputs.app-name }}
           profile: dev
-          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
-          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          image-tag: ${{ needs.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  needs.build-and-push-nonprod.outputs.image-tag  }}
 
   deploy-testing:
     environment: testing
@@ -152,8 +153,8 @@ jobs:
         with:
           application: ${{ inputs.app-name }}
           profile: testing
-          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
-          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          image-tag: ${{  needs.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  needs.build-and-push-nonprod.outputs.image-tag  }}
       - name: Cancel previous workflows run
         uses: bucketplace/github-action-ci-workflows/.github/actions/cancel-previous-workflows@v1
         with:
@@ -174,8 +175,8 @@ jobs:
         with:
           application: ${{ inputs.app-name }}
           profile: staging
-          image-tag: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
-          version: ${{  steps.build-and-push-nonprod.outputs.image-tag  }}
+          image-tag: ${{  needs.build-and-push-nonprod.outputs.image-tag  }}
+          version: ${{  needs.build-and-push-nonprod.outputs.image-tag  }}
 
   build-and-push-prod:
     environment: prod
@@ -230,8 +231,8 @@ jobs:
         with:
           application: ${{ inputs.app-name }}
           profile: prod
-          image-tag: ${{  steps.build-and-push-prod.outputs.image-tag  }}
-          version: ${{  steps.build-and-push-prod.outputs.image-tag  }}
+          image-tag: ${{ needs.build-and-push-prod.outputs.image-tag  }}
+          version: ${{ needs.build-and-push-prod.outputs.image-tag  }}
   
   github-release:
     if: inputs.auto-release

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       version:
-        required: true
+        required: false
         description:  "릴리즈 Tag 버전 (semver)"
         type: string
       release-note:
@@ -24,6 +24,12 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
+    - name: Get Tag
+      id: get-tag
+      uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@main
+      with:
+        app-name: ${{ inputs.app-name }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Get Date
       id: get-date
       run: echo "::set-output name=value::$(date +'%y%m%d')"
@@ -35,5 +41,5 @@ jobs:
         body: |
           ## Release Note
           ${{ inputs.release-note }}
-        name: ${{ inputs.app-name }}-v${{ inputs.version }}@${{ steps.get-date.outputs.value }}
-        tag_name: ${{ inputs.app-name }}-v${{ inputs.version }}
+        name: ${{ steps.get-tag.outputs.next-tag }}@${{ steps.get-date.outputs.value }}
+        tag_name: ${{ steps.get-tag.outputs.next-tag }}

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get Tag
       id: get-tag
       uses: bucketplace/github-action-ci-workflows/.github/actions/release-tag-finder@main

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -1,0 +1,39 @@
+name: "Create Release"
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: "앱 이름"
+        required: true
+        type: string
+      version:
+        required: true
+        description:  "릴리즈 Tag 버전 (semver)"
+        type: string
+      release-note:
+        description: "릴리즈 기록"
+        default: "특이사항 없음"
+        required: false
+        type: string
+
+jobs:
+  github-release:
+    name: Create
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Get Date
+      id: get-date
+      run: echo "::set-output name=value::$(date +'%y%m%d')"
+      shell: bash
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: true
+        body: |
+          ## Release Note
+          ${{ inputs.release-note }}
+        name: ${{ inputs.app-name }}-v${{ inputs.version }}@${{ steps.get-date.outputs.value }}
+        tag_name: ${{ inputs.app-name }}-v${{ inputs.version }}

--- a/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
+++ b/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
@@ -39,13 +39,17 @@ jobs:
         id: get-sha
         run: |
           cd ${{ github.workspace }}/get-sha-temp
-          echo "::set-output name=short-sha::$(git rev-parse --short=10 HEAD)"
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(git rev-parse --short=10 HEAD)
           rm -rf ${{ github.workspace }}/get-sha-temp
+          echo "::set-output name=short-sha::${SHORT_SHA}"
+          echo "::set-output name=sha::${SHA}"
+
+          echo "main sha: ${SHA}, current sha: ${{github.sha}}" >> "$GITHUB_STEP_SUMMARY"
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run gradle for sonarqube
-        if: ${{ steps.get-sha.outputs.sha != github.sha }} # Do not run if it is prod and not a head sha
+        if: ${{ steps.get-sha.outputs.sha == github.sha }} # Do not run if it is prod and not a head sha
         id: gradle-run
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
+++ b/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
@@ -1,0 +1,69 @@
+name: "Check Kotlin"
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: "앱 이름"
+        required: true
+        type: string
+      app-path:
+        type: string
+        description: "앱 기준 디렉토리"
+        required: false
+        default: "."
+      gradlew-path:
+        type: string
+        description: "gradlew가 있는 path"
+        required: false
+        default: "."
+      sonar-host-url:
+        type: string
+        description: "host url of sonarqube"
+        required: false
+        default: "https://sonarqube.co-workerhou.se"
+    secrets:
+      SONAR_TOKEN:
+        required: true
+jobs:   
+  submit-sonarqube:
+    name: Submit Sonarqube
+    runs-on: [self-hosted, Linux, X64, mortar-runner]
+    steps:
+      - name: Checkout Code for Get Main SHA
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}/get-sha-temp
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Get Main SHA
+        id: get-sha
+        run: |
+          cd ${{ github.workspace }}/get-sha-temp
+          echo "::set-output name=short-sha::$(git rev-parse --short=10 HEAD)"
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          rm -rf ${{ github.workspace }}/get-sha-temp
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run gradle for sonarqube
+        if: ${{ steps.get-sha.outputs.sha != github.sha) }} # Do not run if it is prod and not a head sha
+        id: gradle-run
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
+          GRADLE_USER_HOME: /runner/.gradle
+        run: |
+          ${{ inputs.gradlew-path }}/gradlew sonarqube \
+          --project-dir=${{ inputs.app-path }} \
+          --info \
+          --continue \
+          -Dsonar.qualitygate.wait=false \
+          -Dsonar.projectVersion='${{ steps.get-sha.outputs.short-sha }}' \
+          -Dsonar.projectName="${{ inputs.app-name }}"
+        shell: bash
+      - if: failure()
+        name: Upload Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: Failure Reports
+          path: ${{ inputs.app-path }}/build/reports/
+  

--- a/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
+++ b/.github/workflows/reusable-submit-sonarqube-analysis-kotlin.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run gradle for sonarqube
-        if: ${{ steps.get-sha.outputs.sha != github.sha) }} # Do not run if it is prod and not a head sha
+        if: ${{ steps.get-sha.outputs.sha != github.sha }} # Do not run if it is prod and not a head sha
         id: gradle-run
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
## 메인 변경사항
### Common
- app-name 기반의 Monorepo 형식 지원
- gradle 기반 build (gradle 설정을 그대로 사용할 수 있음)
### reusable-check-kotlin.yml
- [kotlin coding style guide](https://go/kotlin-coding-style-guide) 및 [testing guide](https://go/kotlin-testing-guide)에 명시된 대로 설정된 프로젝트일 경우 lint, test 및 sonarqube를 통한 report등의 체크를 설정 해준다.
- lint는 reviewdog을 이용하여 아래 각각의 경우에 맞춰 report를 작성해준다.
  - Pull Request : Review comment 형식으로 보고
  - Push : report 형식으로 보고
  - workflow_dispatch: Text 형식으로 보고
- test는 coverage를 스크린샷처럼 출력해준다.
![스크린샷 2022-09-14 오전 12 47 04](https://user-images.githubusercontent.com/6038531/189950472-da05b383-2d2b-4c64-986d-2f0a0b826876.png)
- sonarqube 에 analysis를 등록하고 70% Coverage 확인에 실패할 경우 실패한다.
- 실패시 Failure Report artifact를 다운받아 실제 report들을 확인할 수 있다.
![스크린샷 2022-09-14 오전 12 47 49](https://user-images.githubusercontent.com/6038531/189950702-c7b58e59-8919-40eb-ad5b-e234fabe646a.png)

### reusable-deploy-mortar.yml
- 아래와 같이 mortar kotlin 프로젝트의 pipeline 을 구성해준다.
![스크린샷 2022-09-13 오후 1 32 45](https://user-images.githubusercontent.com/6038531/189951391-dfef52f4-a61f-491b-847a-20e0ac94d2cd.png)
- check-kotlin을 사용해 버전을 검증하고 각 환경에 배포하는 pipeline을 구성한다.
- NonProd -> Dev, Testing, Staging ~~~ Prod -> Prod 형태로 배포된다.
- 각 배포 환경은 (Deploy - XX)는 environment 설정이 되어 있으므로, environment 에서 approval 설정을 할 수 있다.

### reusable-github-release.yml
- `<app-name>-v<version>@<yymmdd>` 형태의 release

## Test
- [bucketplace/github-action-playground](https://github.com/bucketplace/github-action-playground/tree/master/test-package/mortar-kotlin) 의 `test-package/mortar-kotlin`아래 파일을 변경하여 PR 생성 및 merge 하면서 테스트 가능.
